### PR TITLE
add travis status img

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Build Status](https://travis-ci.org/AppDevelopUNQ/desapp-groupA-backend.svg?branch=master)](https://travis-ci.org/AppDevelopUNQ/desapp-groupA-backend)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/98f6b17640124d828e3555dda340c300)](https://app.codacy.com/manual/appdevelop.unq/desapp-groupA-backend?utm_source=github.com&utm_medium=referral&utm_content=AppDevelopUNQ/desapp-groupA-backend&utm_campaign=Badge_Grade_Settings)
 [![Coverage Status](https://coveralls.io/repos/github/AppDevelopUNQ/desapp-groupA-backend/badge.svg?branch=master)](https://coveralls.io/github/AppDevelopUNQ/desapp-groupA-backend?branch=master)
 


### PR DESCRIPTION
Agregue la img de travis al markdown para poder tener una vision de como esta el estado de la integracion continua.